### PR TITLE
Catch errors is ext parser and emit on the stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,11 +58,14 @@ function gulpExtjs(options) {
             opts.fileProvider = createVinylFileProvider(cwd, entryFilesByPath);
             opts.entry = entryFilePaths;
 
-            var extFileInfos = extdeps.resolve(opts);
-
-            extFileInfos.forEach(function(fileInfo) {
-                me.push(fileInfo.content.vinylFile);
-            });
+            try {
+                var extFileInfos = extdeps.resolve(opts);
+                extFileInfos.forEach(function(fileInfo) {
+                    me.push(fileInfo.content.vinylFile);
+                });
+            } catch (e) {
+                me.emit('error', new PluginError(PLUGIN_NAME, e));
+            }
 
             callback();
         });


### PR DESCRIPTION
Currently gulp-extjs throws an exception when extjs dependency parser fails. This change catches that error and emits it on the stream. This allows gulp in watch mode to keep going when a parse error is encountered. Works well with other pull request to extjs-dependencies that adds the filename to the error.