### PR TITLE
Replace deprecated dependency `gulp-util`  with `plugin-error` package.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,7 @@ var fs = require('fs');
 var extdeps = require('extjs-dependencies');
 var Vinyl = require('vinyl');
 var through = require('through2');
-var gutil = require('gulp-util');
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 
 const PLUGIN_NAME = 'gulp-extjs';
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "index.js",
   "dependencies": {
     "extjs-dependencies": "^1.4.0",
-    "gulp-util": "^3.0.7",
+    "plugin-error": "^1.0.1",
     "through2": "^3.0.0",
     "vinyl": "^2.0.0"
   },


### PR DESCRIPTION
`gulp-util` is outdated.   This library generate warning with install:

`npm WARN deprecated gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5`

